### PR TITLE
Set view as empty with double tap

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -209,6 +209,7 @@ public class SignaturePad extends View {
                 getParent().requestDisallowInterceptTouchEvent(true);
                 mPoints.clear();
                 if (isDoubleClick()) {
+                    this.clearView();
                     setIsEmpty(true);
                     break;
                 }
@@ -414,7 +415,6 @@ public class SignaturePad extends View {
             } else if (mCountClick == 2) {
                 long lastClick = System.currentTimeMillis();
                 if (lastClick - mFirstClick < DOUBLE_CLICK_DELAY_MS) {
-                    this.clearView();
                     return true;
                 }
             }

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -208,7 +208,10 @@ public class SignaturePad extends View {
             case MotionEvent.ACTION_DOWN:
                 getParent().requestDisallowInterceptTouchEvent(true);
                 mPoints.clear();
-                if (isDoubleClick()) break;
+                if (isDoubleClick()) {
+                    setIsEmpty(true);
+                    break;
+                }
                 mLastTouchX = eventX;
                 mLastTouchY = eventY;
                 addPoint(getNewPoint(eventX, eventY));


### PR DESCRIPTION
Updated the `mIsEmpty` flag once the user double taps the signature pad. 
Previous to this modification, if the user signed the view, and double tapped, the method `isClear()` would always return `false`.